### PR TITLE
Add Nix shell configuration for development use

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,9 @@
+{
+  pkgs ? import <nixpkgs> { },
+}:
+pkgs.mkShell {
+  buildInputs = with pkgs; [
+    bun
+    prisma-engines
+  ];
+}


### PR DESCRIPTION
This simply adds a Nix shell configuration for development purposes. This is particularly useful on NixOS, which is designed for development with Nix shells in mind, and thus commonly depends on this feature.

When loading the shell, `bun` and `prisma-engines` are installed as packages for the shell. The latter is present, because Prisma cannot download an engine on NixOS, and thus requires `prisma-engines` as a system package for this purpose.